### PR TITLE
Don't emit "complete" until all tasks have actually completed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ traverse.directory(function(source, target, next) {
   the "next" argument is a function which expects three arguments
   which handle how the source / target are handled.
 
+  You must call next() to indicate that the item has been handled.
+  If you have no action to take, just call next() with no arguments.
+
   @param {Function} action (see below) to handle source/target.
   @param {String} source path.
   @param {String} target path.
@@ -43,8 +46,8 @@ traverse.directory(function(source, target, next) {
   next(TraverseDirectory.copydir, source, target);
 });
 
-/** 
-Handle file found in a directory. Unlike the directory 
+/**
+Handle file found in a directory. Unlike the directory
 command file is optional (though generally needed).
 
 @param {String} source directory.
@@ -74,6 +77,10 @@ TraverseDirectory = require('traverse-directory');
 
 // somewhere in the directory or file methods.
 next(TraverseDirectory[ACTION_NAME], source, target);
+
+// If you are doing something inline that doesn't need handing
+// off to an action, just call without arguments
+next();
 ```
 
 For examples on how to write actions see index.js.

--- a/test/copydir-test.js
+++ b/test/copydir-test.js
@@ -32,8 +32,9 @@ suite('copydir', function() {
     setup(function(done) {
       var traverse = traverseDir(root, '/dev/null');
 
-      traverse.file(function(source) {
+      traverse.file(function(source, target, next) {
         output[source.replace(root, '')] = fs.readFileSync(source, 'utf8');
+        next();
       });
 
       traverse.directory(function(source, target, next) {

--- a/test/symlinktree-test.js
+++ b/test/symlinktree-test.js
@@ -1,0 +1,43 @@
+suite('symlink a directory tree with files', function() {
+  var traverseDir = require('../');
+  var fs = require('fs');
+  var path = require('path');
+  var remove = require('remove');
+
+  var source = path.join(FIXTURES, 'read');
+  var target = path.join(FIXTURES, 'read-out');
+
+  teardown(function(done) {
+    fs.exists(target, function(exists) {
+      if(exists) {
+        remove(target, done);
+      } else {
+        done();
+      }
+    });
+  });
+
+  test('from source to target, asynchronously', function(done) {
+    var traverse = traverseDir(source, target);
+
+    traverse.file(function(source, target, next) {
+        setTimeout(function() {
+            next(traverseDir.symlinkfile, source, target);
+        }, 10);
+    });
+
+    traverse.directory(function(source, target, next) {
+        next(traverseDir.copydir, source, target);
+    });
+
+    traverse.run();
+
+    traverse.on('complete', function() {
+        done();
+    });
+
+    traverse.on('error', function(err) {
+        done(err);
+    });
+  });
+});


### PR DESCRIPTION
Hi there,

My team was running into a problem where "complete" was firing before all the files in our directory tree had been symlinked. We tracked it down to the fact that we were running `next()` asynchronously:

``` javascript
traverse.file(function(source, target, next) {
    fs.unlink(target, function() {
        // Async
        next(TraverseDirectory.symlinkfile, source, target);
    });
});
```

And traverse was reporting complete before the async operations completed. This PR should fix that behavior. I added a unit test as well (it doesn't compare the output, it simply ensures that async operations work as expected, since there are already tests around the Actions themselves).

This does mean that next() has to be called (even without an Action), but I think that was expected anyways. I fixed one unit test that didn't call next() and updated the documentation slightly.

Thanks for your time!
